### PR TITLE
Changed to mainline coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.xml
 docs/_build
 build
+dist

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   override:
     - pip install --upgrade pip
     - pip install --upgrade setuptools
-    - pip install coveralls
+    - pip install git+https://github.com/coagulant/coveralls-python.git
 
 test:
   override:


### PR DESCRIPTION
@tabac, this PR enables the use of 'mainline' coveralls (version 1.1) after coagulant/coveralls-python#94